### PR TITLE
Add sorted dictionary structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+**0.8.0**
+
+- Added `SortedDictionary` structure

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ compliance oversights, please send a patch via pull request.
 stores values identified by a key. Only associative arrays can be used to
 initialize the structure. Any value can be defined by a string key.
 
+**`SortedDictionary`** is an implementation of a [associative array][wiki-dict]
+that also sorts the array. By default the array is sorted by value. The array
+is sorted every time the content or sorting method changes.
+
 **`OrderedList`** is an implementation of a [list][wiki-list] that stores ordered
 values. Only an indexed array can be used to initialize the structure. Any value
 can be added. When the list is exposed it will be sorted by the defined callable.

--- a/src/Ability/HashStorage.php
+++ b/src/Ability/HashStorage.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Destrukt\Ability;
+
+trait HashStorage
+{
+    /**
+     * Check if a given value is defined.
+     *
+     * @param  string $key
+     * @return boolean
+     */
+    public function hasValue($key)
+    {
+        return array_key_exists($key, $this->data);
+    }
+
+    /**
+     * Get a value from the hash.
+     *
+     * If the value does not exist, the default will be returned.
+     *
+     * @param  string $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getValue($key, $default = null)
+    {
+        if ($this->hasValue($key)) {
+            return $this->data[$key];
+        }
+        return $default;
+    }
+
+    /**
+     * Get a copy with an new value.
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return self
+     */
+    public function withValue($key, $value)
+    {
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException(
+                'Dictionary key must be a string'
+            );
+        }
+
+        $this->validate([$key => $value]);
+
+        $copy = clone $this;
+        $copy->data[$key] = $value;
+
+        return $copy;
+    }
+
+    /**
+     * Get a copy without a given key.
+     *
+     * @param  string $key
+     * @return self
+     */
+    public function withoutValue($key)
+    {
+        $copy = clone $this;
+        unset($copy->data[$key]);
+
+        return $copy;
+    }
+
+    // StructInterface
+    abstract public function validate(array $data);
+}

--- a/src/Ability/SortedStorage.php
+++ b/src/Ability/SortedStorage.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Destrukt\Ability;
+
+use Destrukt\StructInterface;
+
+trait SortedStorage
+{
+    use Storage {
+        replaceData as replaceDataUsingStorage;
+    }
+
+    /**
+     * Get a copy with a different sorting method.
+     *
+     * @param callable $sorter
+     *
+     * @return self
+     */
+    public function withSorter(callable $sorter)
+    {
+        if ($this->sorter === $sorter) {
+            return $this;
+        }
+
+        $copy = clone $this;
+        $copy->sorter = $sorter;
+        $copy->replaceData($this->data);
+
+        return $copy;
+    }
+
+    /**
+     * Replace existing data with fresh data that is sorted
+     *
+     * @param array $data
+     *
+     * @return void
+     */
+    private function replaceData(array $data)
+    {
+        $this->replaceDataUsingStorage($data);
+
+        // Hack to work around call_user_func being unable to pass by reference.
+        // This is the offically recommended solution from http://php.net/call_user_func
+        call_user_func_array($this->sorter, array(&$this->data));
+    }
+}

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -8,6 +8,7 @@ class Dictionary implements StructInterface
 {
     use Ability\Similar;
     use Ability\Storage;
+    use Ability\HashStorage;
 
     public function validate(array $data)
     {
@@ -16,70 +17,5 @@ class Dictionary implements StructInterface
                 'Dictionary must be indexed by keys'
             );
         }
-    }
-
-    /**
-     * Check if a given value is defined.
-     *
-     * @param  string $key
-     * @return boolean
-     */
-    public function hasValue($key)
-    {
-        return array_key_exists($key, $this->data);
-    }
-
-    /**
-     * Get a value from the hash.
-     *
-     * If the value does not exist, the default will be returned.
-     *
-     * @param  string $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    public function getValue($key, $default = null)
-    {
-        if ($this->hasValue($key)) {
-            return $this->data[$key];
-        }
-        return $default;
-    }
-
-    /**
-     * Get a copy with an new value.
-     *
-     * @param  string $key
-     * @param  mixed  $value
-     * @return self
-     */
-    public function withValue($key, $value)
-    {
-        if (!is_string($key)) {
-            throw new \InvalidArgumentException(
-                'Dictionary key must be a string'
-            );
-        }
-
-        $this->validate([$key => $value]);
-
-        $copy = clone $this;
-        $copy->data[$key] = $value;
-
-        return $copy;
-    }
-
-    /**
-     * Get a copy without a given key.
-     *
-     * @param  string $key
-     * @return self
-     */
-    public function withoutValue($key)
-    {
-        $copy = clone $this;
-        unset($copy->data[$key]);
-
-        return $copy;
     }
 }

--- a/src/SortedDictionary.php
+++ b/src/SortedDictionary.php
@@ -4,22 +4,22 @@ namespace Destrukt;
 
 use Destrukt\Ability;
 
-class OrderedList implements StructInterface
+class SortedDictionary implements StructInterface
 {
+    use Ability\HashStorage;
     use Ability\Similar;
     use Ability\SortedStorage;
-    use Ability\ValueStorage;
 
     /**
      * @var callable
      */
-    private $sorter = 'sort';
+    private $sorter = 'asort';
 
     public function validate(array $data)
     {
-        if (array_values($data) !== $data) {
+        if (!empty($data) && array_keys($data) === array_keys(array_values($data))) {
             throw new \InvalidArgumentException(
-                'List structures cannot be indexed by keys'
+                'Dictionary must be indexed by keys'
             );
         }
     }

--- a/tests/SortedDictionaryTest.php
+++ b/tests/SortedDictionaryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Destrukt;
+
+class SortedDictionaryTest extends DictionaryTest
+{
+    public function setUp()
+    {
+        $this->struct = new SortedDictionary([
+            'one'   => 1,
+            'two'   => 2,
+            'three' => 3,
+            'four'  => 4,
+        ]);
+    }
+
+    public function testSorting()
+    {
+        $values = $this->struct->toArray();
+
+        asort($values);
+
+        $this->assertSame($values, $this->struct->toArray());
+
+        $copy = $this->struct->withSorter('ksort');
+
+        ksort($values);
+
+        $this->assertSame($values, $copy->toArray());
+    }
+}


### PR DESCRIPTION
There are some situations where an sorted hash is required.
For example when working with values that also have a quality or count,
it is often necessary to sort them before output.

To support this data type some functionality from Dictionary has been
split into HashStorage, similar to ValueStorage for lists, and a new
SortedStorage trait is added to be used instead of Storage.